### PR TITLE
customize template in script-tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This Addon manages the following settings (all of them switchable inside the UI)
     + run the embedded server, click on the `Start Serving` button
     + run `live-server` (install it with `npm install -g live-server`)
     + run `python -m SimpleHTTPServer`
++ Customize the 'index.html'-template in the Script-tab for future exports
 
 For massive exports, 'live-server' could be more useful because it can manage a content auto-refresh.
 

--- a/__init__.py
+++ b/__init__.py
@@ -138,9 +138,12 @@ class Server(threading.Thread):
 
 
 # Index html a-frame template
-t = Template('''
-<!-- Generated automatically by AFRAME Exporter for Blender - https://silverslade.itch.io/a-frame-blender-exporter -->
-<html>
+def default_template():
+    if not bpy.data.texts.get('index.html'):
+        tpl = bpy.data.texts.new('index.html')
+        tpl.from_string('''<!doctype html>
+<html lang="en">
+    <!-- Generated automatically by AFRAME Exporter for Blender - https://silverslade.itch.io/a-frame-blender-exporter -->
     <head>
         <title>WebXR Application</title>
         <link rel="icon" type="image/png" href="favicon.ico"/>
@@ -671,6 +674,8 @@ class AframeExport_OT_Operator(bpy.types.Operator):
             light_directional_intensity = "1.0"
             light_ambient_intensity = "1.0"
 
+        default_template()
+        t = Template( bpy.data.texts['index.html'].as_string() )
         s = t.substitute(
             asset=all_assets,
             entity=all_entities,

--- a/__init__.py
+++ b/__init__.py
@@ -547,6 +547,7 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                 animation = ""
                 link = ""
                 baked = ""
+                custom = ""
                 video = False
                 image = False
 
@@ -561,12 +562,12 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                                     reflections = ' geometry="" camera-cube-env="distance: 500; resolution: 512; repeat: true; interval: 400" '
                                 else:
                                     reflections = ' geometry="" cube-env-map="path: '+scene.s_cubemap_path+'; extension: '+scene.s_cubemap_ext+'; reflectivity: 0.99;" '
-                            if K == "AFRAME_ANIMATION":
+                            elif K == "AFRAME_ANIMATION":
                                 animation = ' animation= "'+obj[K]+'" '
-                            if K == "AFRAME_HTTP_LINK":
+                            elif K == "AFRAME_HTTP_LINK":
                                 #link = ' link="href: '+obj[K]+'" class="clickable" '
                                 link = ' link-handler="target: '+obj[K]+'" class="clickable" '
-                            if K == "AFRAME_VIDEO":
+                            elif K == "AFRAME_VIDEO":
                                 #print("--------------- pos " + actualposition)
                                 #print("--------------- rot " + actualrotation)
                                 #print("--------------- scale " + actualscale)                                
@@ -579,7 +580,7 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                                 #entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" gltf-model="#'+obj.name+'" material="src: #video_'+str(videocount)+'" scale="'+actualscale+'" rotation="'+actualrotation+'" position="'+actualposition+'"></a-entity>')
                                 video = True
                                 videocount = videocount +1
-                            if K == "AFRAME_IMAGES":
+                            elif K == "AFRAME_IMAGES":
                                 #print(".....images")
                                 image = True
                                 imagecount = imagecount +1
@@ -591,6 +592,9 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                                     #print(key, ":", json_dictionary[key])
                                     assets.append('\n\t\t\t\t<img id="image_'+key+'" src="./media/'+json_dictionary[key]+'"></img>')
                                 entities.append('\n\t\t\t<a-image images-handler id="#i_'+str(imagecount)+'" src="#image_'+key+'" class="clickable" width="1" height="1" scale="'+actualscale+'" position="'+actualposition+'" rotation="'+actualrotation+'" visible="true" shadow="cast: false"></a-image>')
+                            elif K.startswith('AFRAME_'):
+                                attr   = K.split("AFRAME_")[1].lower()
+                                custom = custom+' '+attr+'="'+obj[K]+'"'
 
                     if video == False and image == False:                        
                         # check if baked texture is present on filesystem
@@ -609,9 +613,9 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                         bpy.ops.export_scene.gltf(filepath=filename, export_format='GLTF_EMBEDDED', use_selection=True)
                         assets.append('\n\t\t\t\t<a-asset-item id="'+obj.name+'" src="./assets/'+obj.name + '.gltf'+'"></a-asset-item>')
                         if scene.b_cast_shadows:
-                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: true" '+reflections+animation+link+'></a-entity>')
+                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: true" '+reflections+animation+link+custom+'></a-entity>')
                         else:
-                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" '+baked+' gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: false" '+reflections+animation+link+'></a-entity>')
+                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" '+baked+' gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: false" '+reflections+animation+link+custom+'></a-entity>')
                 # deselect object
                 obj.location = location
                 obj.select_set(state=False)


### PR DESCRIPTION
Hi, thanks for this cool plugin, I've added 2 customization features:

## 1. custom index.html

After your first export, this patch will create the 'index.html'-template in the Script-workspace:

![image](https://user-images.githubusercontent.com/180068/88905357-7a5a9a80-d256-11ea-98a3-38e550fcb242.png)

That way you can easily customize the exported index.html.
(Think adding analytics, JS, a-frame libraries e.g.).

> NOTE: index.html is an internal text-file which gets saved into the `.blend` file. Awesome isn't it?

## 2. unknown `AFRAME_*` custom attributes will map to aframe attributes automatically

Let's say you're using an aframe plugin `foo` which is configurable using `foo`-attributes:

![image](https://user-images.githubusercontent.com/180068/88921151-51460400-d26e-11ea-9251-831369b686ba.png)

will then be generated as:

`<a-entity .... foo-bar="{value)">`

> this is quite powerful, as it is impossible to just hardcode every possible future a-frame feature into this addon. Hope you like it.
