### PR TITLE
Feature/custom tag and nogltf

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This Addon manages the following settings (all of them switchable inside the UI)
     + run `live-server` (install it with `npm install -g live-server`)
     + run `python -m SimpleHTTPServer`
 + Customize the 'index.html'-template in the Script-tab for future exports
++ Use `Custom Properties` of blender-objects to control tags/attributes ([example](https://gist.github.com/coderofsalvation/2468dc3dfbaca0520cd65c20dfad7eb8))
 
 For massive exports, 'live-server' could be more useful because it can manage a content auto-refresh.
 

--- a/__init__.py
+++ b/__init__.py
@@ -598,6 +598,8 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                 toggle = ""
                 video = False
                 image = False
+                tag = "entity"
+                gltf_model = 'gltf-model="#'+obj.name+'"' 
 
                 # export gltf
                 if obj.type == 'MESH':
@@ -642,6 +644,10 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                                 entities.append('\n\t\t\t<a-image images-handler id="#i_'+str(imagecount)+'" src="#image_'+key+'" class="clickable" width="1" height="1" scale="'+actualscale+'" position="'+actualposition+'" rotation="'+actualrotation+'" visible="true" shadow="cast: false"></a-image>')
                             elif K == "AFRAME_SHOW_HIDE_OBJECT":
                                 toggle = ' toggle-handler="target: #'+obj[K]+';" class="clickable" '
+                            elif K == "AFRAME_TAG":
+                                tag = obj[K]
+                            elif K == "AFRAME_NOGLTF":
+                                gltf_model = ""
                             elif K.startswith('AFRAME_'):
                                 attr   = K.split("AFRAME_")[1].lower()
                                 custom = custom+' '+attr+'="'+str(obj[K])+'"'
@@ -663,9 +669,9 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                         bpy.ops.export_scene.gltf(filepath=filename, export_format='GLTF_EMBEDDED', use_selection=True)
                         assets.append('\n\t\t\t\t<a-asset-item id="'+obj.name+'" src="./assets/'+obj.name + '.gltf'+'"></a-asset-item>')
                         if scene.b_cast_shadows:
-                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: true" '+reflections+animation+link+custom+toggle+'></a-entity>')
+                            entities.append('\n\t\t\t<a-'+tag+' id="#'+obj.name+'" '+gltf_model+' scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: true" '+reflections+animation+link+custom+toggle+'></a-'+tag+'>')
                         else:
-                            entities.append('\n\t\t\t<a-entity id="#'+obj.name+'" '+baked+' gltf-model="#'+obj.name+'" scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: false" '+reflections+animation+link+custom+toggle+'></a-entity>')
+                            entities.append('\n\t\t\t<a-'+tag+' id="#'+obj.name+'" '+gltf_model+' '+baked+' scale="1 1 1" position="'+actualposition+'" visible="true" shadow="cast: false" '+reflections+animation+link+custom+toggle+'></a-'+tag+'>')
                 # deselect object
                 obj.location = location
                 obj.select_set(state=False)

--- a/__init__.py
+++ b/__init__.py
@@ -602,7 +602,10 @@ class AframeExport_OT_Operator(bpy.types.Operator):
                 gltf_model = 'gltf-model="#'+obj.name+'"' 
 
                 # export gltf
-                if obj.type == 'MESH':
+                print(obj.type)
+                if obj.type == 'MESH' or obj.type == 'EMPTY':
+                    if obj.type == 'EMPTY':
+                        gltf_model = ''
                     #print(obj.name,"custom properties:")
                     for K in obj.keys():
                         if K not in '_RNA_UI':


### PR DESCRIPTION
* `AFRAME_TAG` allows overriding the exported tag of an object instead of default `<a-entity>`
* `AFRAME_NOGLTF` allows disabling the `gltf-model=""` attribute (was needed for properly displaying `<a-image>` e.g.)
* empty blender-objects are now also exported (as empty `<a-entity>`) , very useful as 3d placeholders enhanced by js

See example [here](https://gist.github.com/coderofsalvation/2468dc3dfbaca0520cd65c20dfad7eb8)