### PR TITLE
Fix saving to PNG

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -444,6 +444,9 @@ class AframeSavelm_OT_Operator(bpy.types.Operator):
     def execute(self, content):
         images = bpy.data.images
         scene = content.scene
+        original_format = scene.render.image_settings.file_format
+        settings = scene.render.image_settings
+        settings.file_format = 'PNG'
         DEST_RES = os.path.join ( scene.export_path, scene.s_project_name )
         for img in images:
             if "_baked" in img.name and img.has_data:
@@ -454,6 +457,7 @@ class AframeSavelm_OT_Operator(bpy.types.Operator):
                 img.file_format = 'PNG'
                 img.save_render(os.path.join ( DEST_RES, PATH_LIGHTMAPS, img.name+ext ) )
                 print("[SAVE LIGHTMAPS] Save image "+img.name)
+        settings.file_format = original_format
         return {'FINISHED'}
     
 class AframeLoadlm_OT_Operator(bpy.types.Operator):


### PR DESCRIPTION
I've encountered an issue in Blender 2.90.1 (though I haven't tried different versions), where if I try to save the lightmaps, I get files that end with '.png' but don't appear to be PNGs. I think the issue is that the image via save_render is saved with the file_format set for the scene, regardless of what img.file_format is. I've been using this way of saving the image and it seems to work fine.

Happy to adjust or withdraw the PR if I'm doing something wrong, though! Just started using your addon! Amazing stuff :)